### PR TITLE
Improved pattern matching

### DIFF
--- a/.github/workflows/self-tests.yml
+++ b/.github/workflows/self-tests.yml
@@ -314,7 +314,7 @@ jobs:
         id: extract
         uses: telicent-oss/extract-release-notes-action@v1
         with:
-          changelog-file: test-data/named.md
+          changelog-file: test-data/titled.md
           version: ${{ matrix.version }}
           fail-if-missing: true
           attach-release-notes: true

--- a/.github/workflows/self-tests.yml
+++ b/.github/workflows/self-tests.yml
@@ -262,3 +262,77 @@ jobs:
         run: |
           echo "Release Note Extraction should have failed"
           exit 1
+
+  named-success:
+    strategy:
+      matrix:
+        version: [ "1.0.0", "1.1.0" ]
+      fail-fast: false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Extract Release Notes
+        id: extract
+        uses: telicent-oss/extract-release-notes-action@v1
+        with:
+          changelog-file: test-data/named.md
+          version: ${{ matrix.version }}
+          fail-if-missing: true
+          attach-release-notes: true
+          job-summary: true
+
+      - name: Print Outputs for Debugging
+        run: |
+          echo "Release Notes file is ${{ steps.extract.outputs.release-notes-file }}"
+          echo "Auto-Release notes set to ${{ steps.extract.outputs.auto-release-notes }}"
+          echo "Release Notes artifact is ${{ steps.extract.outputs.release-notes-artifact }}"
+
+      - name: Fail if no release notes output
+        if: ${{ steps.extract.outputs.release-notes-file == '' }}
+        run: |
+          exit 1
+
+      - name: Ensure Release Notes can be downloaded
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ steps.extract.outputs.release-notes-artifact }}
+          path: /tmp/
+
+  titled-success:
+    strategy:
+      matrix:
+        version: [ "1.0.0", "1.0.1" ]
+      fail-fast: false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Extract Release Notes
+        id: extract
+        uses: telicent-oss/extract-release-notes-action@v1
+        with:
+          changelog-file: test-data/named.md
+          version: ${{ matrix.version }}
+          fail-if-missing: true
+          attach-release-notes: true
+          job-summary: true
+
+      - name: Print Outputs for Debugging
+        run: |
+          echo "Release Notes file is ${{ steps.extract.outputs.release-notes-file }}"
+          echo "Auto-Release notes set to ${{ steps.extract.outputs.auto-release-notes }}"
+          echo "Release Notes artifact is ${{ steps.extract.outputs.release-notes-artifact }}"
+
+      - name: Fail if no release notes output
+        if: ${{ steps.extract.outputs.release-notes-file == '' }}
+        run: |
+          exit 1
+
+      - name: Ensure Release Notes can be downloaded
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ steps.extract.outputs.release-notes-artifact }}
+          path: /tmp/

--- a/.github/workflows/self-tests.yml
+++ b/.github/workflows/self-tests.yml
@@ -300,6 +300,32 @@ jobs:
           name: ${{ steps.extract.outputs.release-notes-artifact }}
           path: /tmp/
 
+  named-fail:
+    strategy:
+      matrix:
+        version: [ "1", "1.0", "2.0.0", "0.1.2" ]
+      fail-fast: false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Extract Release Notes
+        id: extract
+        uses: telicent-oss/extract-release-notes-action@v1
+        continue-on-error: true
+        with:
+          changelog-file: test-data/named.md
+          version: ${{ matrix.version }}
+          fail-if-missing: true
+          job-summary: false
+
+      - name: Verify Release Note Extraction Failed
+        if: ${{ steps.extract.outcome == 'success' }}
+        run: |
+          echo "Release Note Extraction should have failed"
+          exit 1
+
   titled-success:
     strategy:
       matrix:
@@ -336,3 +362,29 @@ jobs:
         with:
           name: ${{ steps.extract.outputs.release-notes-artifact }}
           path: /tmp/
+
+  titled-fail:
+    strategy:
+      matrix:
+        version: [ "1", "1.0", "2.0.0", "0.1.2" ]
+      fail-fast: false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Extract Release Notes
+        id: extract
+        uses: telicent-oss/extract-release-notes-action@v1
+        continue-on-error: true
+        with:
+          changelog-file: test-data/titled.md
+          version: ${{ matrix.version }}
+          fail-if-missing: true
+          job-summary: false
+
+      - name: Verify Release Note Extraction Failed
+        if: ${{ steps.extract.outcome == 'success' }}
+        run: |
+          echo "Release Note Extraction should have failed"
+          exit 1

--- a/README.md
+++ b/README.md
@@ -127,9 +127,15 @@ by some space characters, followed by the specified input `version` and then a n
 
 For example if `version` was set to `1.2.3` then both `# 1.2.3` and `### 1.2.3` would be acceptable, but `## 1.2.3.0`
 would not.  Similarly, if your Change Log file has headers like `### Version 1.2.3` then this won't match either.  As of
-`v1.1` of this action we also support more complex headers of the form `### [1.2.3]<additional content>` where
-`<additional content>` is anything else.  Again your input `version` must appear exactly within the brackets to be
-successfully matched.
+`v1.2` of this action we support version headers of any of the following forms:
+
+- `# 1.2.3`
+- `# 1.2.3 (Some additional content)`
+- `# Version 1.2.3`
+- `# [1.2.3](https://example.org/release/1.2.3) Some additional content`
+
+Basically the provided input `version` **MUST** appear surrounded either by whitespace, or square brackets i.e. `[]`.
+You can see the various example Change Logs in our [`test-data`](test-data/) folder for the various acceptable formats.
 
 Once this line is found it then reads all the subsequent lines until the end of file is reached, or another header line
 of the same level is reached.  This means that you can use subheaders in your Change Log provided that the subheader

--- a/action.yml
+++ b/action.yml
@@ -93,7 +93,7 @@ runs:
               fi
             fi
             echo "${LINE}" >> ${{ inputs.release-notes-file }}
-          elif echo "${LINE}" | grep -E "#+[[:space:]]+.*([[]${MATCH_RELEASE}[]]|${MATCH_RELEASE}[[:space:]]).*\$" >/dev/null 2>&1; then
+          elif echo "${LINE}" | grep -E "#+.*([[]${MATCH_RELEASE}[]].*|[[:space:]]+${MATCH_RELEASE}[[:space:]].*|[[:space:]]+${MATCH_RELEASE}\$)" >/dev/null 2>&1; then
             STARTED=1
             HEADER=$(echo "${LINE}" | awk '{print $1}')
             echo "# Version ${RELEASE}" >> ${{ inputs.release-notes-file }}

--- a/action.yml
+++ b/action.yml
@@ -93,7 +93,7 @@ runs:
               fi
             fi
             echo "${LINE}" >> ${{ inputs.release-notes-file }}
-          elif echo "${LINE}" | grep -E "#+[[:space:]]+([[]${MATCH_RELEASE}[]].*|${MATCH_RELEASE}\$)" >/dev/null 2>&1; then
+          elif echo "${LINE}" | grep -E "#+[[:space:]]+.*([[]${MATCH_RELEASE}[]]|${MATCH_RELEASE}[[:space:]]).*\$" >/dev/null 2>&1; then
             STARTED=1
             HEADER=$(echo "${LINE}" | awk '{print $1}')
             echo "# Version ${RELEASE}" >> ${{ inputs.release-notes-file }}

--- a/test-data/named.md
+++ b/test-data/named.md
@@ -1,0 +1,9 @@
+# Change Log
+
+## 1.1.0 (Trendy Gorilla)
+
+Bug fix release
+
+## 1.0.0 (Funky Gibbon)
+
+First release

--- a/test-data/titled.md
+++ b/test-data/titled.md
@@ -1,0 +1,9 @@
+# Change Log
+
+# Version 1.0.1 (21st June 2024)
+
+Bug fix release
+
+# Version 1.0.0 (21st June 2024)
+
+The first release


### PR DESCRIPTION
Improves the version pattern matching to accept a wider range of acceptable version header lines in a Change Log file

@danieldaviestelicent I'm working on ripping out the inline scripts for release note extraction we currently have separately embedded in our respective shared workflows.  This PR is basically just adapting my initial refactor to account for some of the enhancements you made to the script for Python repositories, notably:

- Allowing more flexibility around how the version appears in a header in the file
- Not stopping extraction at a header line if its a sub-header of the version header we started from

Please take a look at some of the additional test files I added as these were based off of examples I found in some of the Python repositories